### PR TITLE
feat: adds page and element-id options on event label and metadata

### DIFF
--- a/src/features/eventCreator/index.ts
+++ b/src/features/eventCreator/index.ts
@@ -1,3 +1,4 @@
+import { EventCreatorParams } from "../../types/event/EventCreatorParams";
 import { EventElement } from "../../types/event/EventElement";
 import { EventHandler } from "../../types/event/EventHandlers";
 import { EventMetadata } from "../../types/event/EventMetadata";
@@ -5,10 +6,17 @@ import { eventActions } from "../../utils/constants/eventActions";
 import { eventElements } from "../../utils/constants/eventElements";
 
 // function to create an object structure [element][action] and returns callback
-export function eventCreator(
-  callback: (cbEventMetadata: unknown) => unknown
-): EventHandler {
+export function eventCreator({
+  callback,
+  options,
+}: EventCreatorParams): EventHandler {
   const handlers: EventHandler = {} as EventHandler;
+
+  const page = options.page.showOnLabel
+    ? `${options.page.currentPage.trim()}.`
+    : "";
+  const showPageOnMetadata = options.page.showOnMetadata;
+
   // iterate over each element
   eventElements.forEach((element) => {
     handlers[element] = {} as EventHandler[EventElement];
@@ -17,7 +25,13 @@ export function eventCreator(
     eventActions.forEach((action) => {
       // define an action handler that receives event metadata
       handlers[element][action] = (eventMetadata: EventMetadata) => {
-        callback({ label: `${element}.${action}`, metadata: eventMetadata });
+        callback({
+          label: `${page}${element}.${action}`,
+          metadata: {
+            ...eventMetadata,
+            ...(showPageOnMetadata ? { page: page.slice(0, -1) } : {}),
+          },
+        });
       };
     });
   });

--- a/src/features/eventCreator/index.ts
+++ b/src/features/eventCreator/index.ts
@@ -16,6 +16,7 @@ export function eventCreator({
     ? `${options.page.currentPage.trim()}.`
     : "";
   const showPageOnMetadata = options.page.showOnMetadata;
+  const showElementIdOnLabel = options.element.showElementIdOnLabel;
 
   // iterate over each element
   eventElements.forEach((element) => {
@@ -25,8 +26,13 @@ export function eventCreator({
     eventActions.forEach((action) => {
       // define an action handler that receives event metadata
       handlers[element][action] = (eventMetadata: EventMetadata) => {
+        const isShowElementId =
+          eventMetadata?.elementId && showElementIdOnLabel;
+        const elementId = isShowElementId
+          ? `.${eventMetadata.elementId.trim()}`
+          : "";
         callback({
-          label: `${page}${element}.${action}`,
+          label: `${page}${element}.${action}${elementId}`,
           metadata: {
             ...eventMetadata,
             ...(showPageOnMetadata ? { page: page.slice(0, -1) } : {}),

--- a/src/features/eventCreator/index.ts
+++ b/src/features/eventCreator/index.ts
@@ -12,11 +12,11 @@ export function eventCreator({
 }: EventCreatorParams): EventHandler {
   const handlers: EventHandler = {} as EventHandler;
 
-  const page = options.page.showOnLabel
-    ? `${options.page.currentPage.trim()}.`
+  const page = options?.page?.showOnLabel
+    ? `${options?.page?.currentPage?.trim()}.`
     : "";
-  const showPageOnMetadata = options.page.showOnMetadata;
-  const showElementIdOnLabel = options.element.showElementIdOnLabel;
+  const showPageOnMetadata = options?.page?.showOnMetadata;
+  const showElementIdOnLabel = options?.element?.showElementIdOnLabel;
 
   // iterate over each element
   eventElements.forEach((element) => {
@@ -29,7 +29,7 @@ export function eventCreator({
         const isShowElementId =
           eventMetadata?.elementId && showElementIdOnLabel;
         const elementId = isShowElementId
-          ? `.${eventMetadata.elementId.trim()}`
+          ? `.${eventMetadata?.elementId?.trim()}`
           : "";
         callback({
           label: `${page}${element}.${action}${elementId}`,

--- a/src/types/event/EventCreatorParams.ts
+++ b/src/types/event/EventCreatorParams.ts
@@ -27,6 +27,7 @@ type EventCreatorParamsOptions = {
     stringCase?: StringCase;
     stringFormat?: StringFormat;
     showOnMetadata?: boolean;
+    showElementIdOnLabel?: boolean;
   };
 };
 

--- a/src/types/event/EventCreatorParams.ts
+++ b/src/types/event/EventCreatorParams.ts
@@ -1,0 +1,36 @@
+type StringFormat =
+  | "camelCase"
+  | "pascalCase"
+  | "snakeCase"
+  | "dotCase"
+  | "kebabCase"
+  | "noCase";
+
+type StringCase = "lowercase" | "uppercase";
+
+type EventCreatorParamsOptions = {
+  page?: {
+    currentPage?: string;
+    stringCase?: StringCase;
+    stringFormat?: StringFormat;
+    showOnLabel?: boolean;
+    showOnMetadata?: boolean;
+  };
+  action?: {
+    possibleActions?: string[];
+    stringCase?: StringCase;
+    stringFormat?: StringFormat;
+    showOnMetadata?: boolean;
+  };
+  element?: {
+    possibleElements?: string[];
+    stringCase?: StringCase;
+    stringFormat?: StringFormat;
+    showOnMetadata?: boolean;
+  };
+};
+
+export interface EventCreatorParams {
+  callback: (cbEventMetadata: unknown) => unknown;
+  options?: EventCreatorParamsOptions;
+}

--- a/src/types/event/EventHandlers.ts
+++ b/src/types/event/EventHandlers.ts
@@ -4,7 +4,7 @@ import { EventMetadata } from "./EventMetadata";
 
 type Element = (typeof eventElements)[number];
 type Action = (typeof eventActions)[number];
-type ActionHandler = (eventMetadata: EventMetadata) => void;
+type ActionHandler = (eventMetadata?: EventMetadata) => void;
 
 export type EventHandler = {
   [key in Element]: {

--- a/src/types/event/EventMetadata.ts
+++ b/src/types/event/EventMetadata.ts
@@ -1,1 +1,1 @@
-export type EventMetadata = unknown;
+export type EventMetadata = Object;

--- a/src/types/event/EventMetadata.ts
+++ b/src/types/event/EventMetadata.ts
@@ -1,1 +1,4 @@
-export type EventMetadata = Object;
+export type EventMetadata = {
+  elementId?: string;
+  [key: string]: unknown;
+};


### PR DESCRIPTION
This PR implements these improvements:
- adds EventCreatorParams for eventCreator function
- adds page on event label and metadata (optionally)
- adds element-id on event lavel and metadata (optionally)

Implementation sample:
```
// callback function
function logEvent(eventMetadata: unknown): unknown {
  console.log(
    "\n---------------EVENT LOG-----------------\n",
    JSON.stringify(eventMetadata, null, 2),
    "\n-------------END OF EVENT LOG-------------\n"
  );
  return;
}

// before
const eventHandler = eventCreator(logEvent);

// now
const eventHandler = eventCreator({
    callback: logEvent,
    options: {
        page: {
            showOnLabel: true,
            currentPage: "home",
            showOnMetadata: true,
        },
        element: {
            showElementIdOnLabel: true,
        },
    },
});

// dispatching event
eventHandler.button.click({
    id: "btn-1",
    timestamp: Date.now(),
    description: "Button clicked",
});
````

Output:
```
 {
    "label": "home.button.click.bnt-1", // now label has: [page].[item].[action].[element-id]
    "page": "home.",
    "metadata": {
          "elementId": "btn-1",
          "timestamp": 1739059943235,
          "description": "Button clicked"
    }
} 
```